### PR TITLE
Update CONN_05_Preprocessing.rst

### DIFF
--- a/docs/FunctionalConnectivity/CONN_ShortCourse/CONN_05_Preprocessing.rst
+++ b/docs/FunctionalConnectivity/CONN_ShortCourse/CONN_05_Preprocessing.rst
@@ -38,7 +38,7 @@ Before the preprocessing can start, you will be prompted to enter a few more opt
 
 For our current tutorial, we will leave it at the intermediate settings.
 
-You will next be prompted to select the sampling resolution of the anatomical and functional output. The defaults of 1mm^3 for the anatomical image and 2mm^3 for the functional images should be fine; if you want to take up less space on your hard drive, you can lower the resolution (i.e., increase the numbers in the fields), at the expense of lower spatial resolution.
+You will next be prompted to select the sampling resolution of the anatomical and functional output. The defaults of (1x1x1)mm^3 for the anatomical image and (2x2x2)mm^3 for the functional images should be fine; if you want to take up less space on your hard drive, you can lower the resolution (i.e., increase the numbers in the fields), at the expense of lower spatial resolution.
 
 Finally, you will be asked to specify a smoothing kernel. As you will see later, the smoothed data by default is omitted from the actual functional connectivity analysis; it is included here in case you want to use it. Click ``OK``, and the preprocessing will begin, calling upon SPM tools as needed. For this subject, it will take about 5 minutes total.
 


### PR DESCRIPTION
i belive that the volume of the anatomical data voxel is 1mm3 (1x1x1), however for functional data voxel the volume is not 2mm3 but (2x2x2)mm3=8mm3.

from the book/paper: Handbook of functional connectivity Magnetic Resonance Imaging methods in CONN https://www.researchgate.net/publication/339460691_Handbook_of_functional_connectivity_Magnetic_Resonance_Imaging_methods_in_CONN

pdf page 15, book page 8

"Both functional and anatomical data are resampled to a default 180x216x180mm bounding box, with 2mm isotropic voxels for functional data and 1mm for anatomical data, using 4th order spline interpolation."

best regards,
Ricardo Martins
ICNAS-UC: Institute of Nuclear Sciences Applied to Health, University of Coimbra